### PR TITLE
Fix extends on CardPayments\Filter

### DIFF
--- a/source/paysafe/cardpayments/filter.php
+++ b/source/paysafe/cardpayments/filter.php
@@ -26,7 +26,7 @@ namespace Paysafe\CardPayments;
  * @property string $startDate
  * @property string $endDate
  */
-class Filter extends JSONObject
+class Filter extends \Paysafe\JSONObject
 {
     protected static $fieldTypes = array(
          'limit' => 'int',


### PR DESCRIPTION
#5 `\Paysafe\CardPayments\Filter` does not properly extend JSONObject. The class def looks like:

`class Filter extends JSONObject`

However, the Filter class is in the CardPayments sub-namespace, while JSONObject is in the root Paysafe namespace.

Based on the definition of DirectDebit\Filter, I believe the class def should be:

`class Filter extends \Paysafe\JSONObject`