### PR TITLE
Adding createCardFromSingleUseToken()

### DIFF
--- a/source/paysafe/CustomerVaultService.php
+++ b/source/paysafe/CustomerVaultService.php
@@ -371,6 +371,32 @@ class CustomerVaultService
     }
 
     /**
+     * Create card from a Single-Use Token.
+     *
+     * @param \Paysafe\CustomerVault\Card $card
+     * @return \Paysafe\CustomerVault\Card
+     * @throws PaysafeException
+     */
+    public function createCardFromSingleUseToken( CustomerVault\Card $card )
+    {
+        $card->setRequiredFields(array('profileID'));
+        $card->checkRequiredFields();
+        $card->setRequiredFields(array(
+            'singleUseToken',
+        ));
+
+        $request = new Request(array(
+            'method' => Request::POST,
+            'uri' => $this->prepareURI("/profiles/" . $card->profileID . "/cards"),
+            'body' => $card
+        ));
+        $response = $this->client->processRequest($request);
+        $response['profileID'] = $card->profileID;
+
+        return new CustomerVault\Card($response);
+    }
+
+    /**
      * Update card.
      *
      * @param \Paysafe\CustomerVault\Card $card


### PR DESCRIPTION
Adding createCardFromSingleUseToken() to support adding a credit card to the Customer Vault by only supplying the single use token (typically generated on the client).