### PR TITLE
Updated api endpoints

### DIFF
--- a/source/Paysafe/PaysafeApiClient.php
+++ b/source/Paysafe/PaysafeApiClient.php
@@ -117,9 +117,9 @@ class PaysafeApiClient
         $this->environment = $environment;
 
         if ($this->environment == Environment::TEST) {
-            $this->apiEndPoint = "https://api.test.paysafe.com";
+            $this->apiEndPoint = "https://api.test.netbanx.com";
         } else {
-            $this->apiEndPoint = "https://api.paysafe.com";
+            $this->apiEndPoint = "https://api.netbanx.com";
         }
 
         $this->account = $account;


### PR DESCRIPTION
The api.paysafe.com urls are no longer valid and perform a 302 redirect to the paysafe homepage. The endpoints in the paysafe api documentation have been updated to api.netbanx.com. The endpoints in the code need updating.