### PR TITLE
Adding storedCredential to authorize method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "paysafegroup/paysafe_sdk_php",
+    "name": "Lampelk/paysafe_sdk_php",
     "type": "library",
     "description": "PHP SDK for the Paysafe API",
     "keywords" : ["payment", "payment processing", "netbanx", "optimal", "sdk"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Lampelk/paysafe_sdk_php",
+    "name": "paysafegroup/paysafe_sdk_php",
     "type": "library",
     "description": "PHP SDK for the Paysafe API",
     "keywords" : ["payment", "payment processing", "netbanx", "optimal", "sdk"],

--- a/source/Paysafe/CardPaymentService.php
+++ b/source/Paysafe/CardPaymentService.php
@@ -88,6 +88,7 @@ class CardPaymentService
              'accordD',
              'description',
              'splitpay',
+	     'storedCredential'
         ));
 
         $request = new Request(array(

--- a/source/Paysafe/CardPayments/Authorization.php
+++ b/source/Paysafe/CardPayments/Authorization.php
@@ -53,6 +53,7 @@ namespace Paysafe\CardPayments;
  * @property \Paysafe\Error $error
  * @property \Paysafe\Link[] $links
  * @property \Paysafe\CardPayments\SplitPay[] $splitpay
+ * @property \Paysafe\CardPayments\StoredCredential $storedCredential
  */
 class Authorization extends \Paysafe\JSONObject implements \Paysafe\Pageable
 {
@@ -114,7 +115,8 @@ class Authorization extends \Paysafe\JSONObject implements \Paysafe\Pageable
          'settlements' => 'array:\Paysafe\CardPayments\Settlement',
          'error' => '\Paysafe\Error',
          'links' => 'array:\Paysafe\Link',
-         'splitpay' => 'array:\Paysafe\CardPayments\SplitPay',
+        'splitpay' => 'array:\Paysafe\CardPayments\SplitPay',
+        'storedCredential' => '\Paysafe\CardPayments\StoredCredential'
     );
 
 }

--- a/source/Paysafe/CardPayments/StoredCredential.php
+++ b/source/Paysafe/CardPayments/StoredCredential.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * TODO insert appropriate copyright notice
+ */
+
+namespace Paysafe\CardPayments;
+
+/**
+ * @property string $type
+ * @property number $occurrence
+ */
+class StoredCredential extends \Paysafe\JSONObject
+{
+    protected static $fieldTypes = array(
+        'type' => array(
+            'ADHOC',
+            'TOPUP',
+            'RECURRING'
+        ),
+        'occurrence' => array(
+            'INITIAL',
+            'SUBSEQUENT'
+        )
+    );
+}

--- a/tests/paysafe/CardPayments/AuthorizationTest.php
+++ b/tests/paysafe/CardPayments/AuthorizationTest.php
@@ -382,6 +382,10 @@ class AuthorizationTest extends \PHPUnit_Framework_TestCase
                 'linkedAccount' => 'link_account_id',
                 'amount' => 500,
             ]],
+            'storedCredential' => [
+                'type' => 'RECURRING',
+                'occurrence' => 'SUBSEQUENT'
+            ]
         ];
         $auth = new Authorization($auth_array);
 


### PR DESCRIPTION
As per API documentation for  recurring payments:
https://developer.paysafe.com/en/cards/api/#/introduction/complex-json-objects/standalonecredits

This field is missing from the optional fields.