### PR TITLE
Add `storedCredential` to Verification field types list

### DIFF
--- a/source/Paysafe/CardPayments/Verification.php
+++ b/source/Paysafe/CardPayments/Verification.php
@@ -80,6 +80,7 @@ class Verification extends \Paysafe\JSONObject implements \Paysafe\Pageable
          'status' => 'string',
          'riskReasonCode' => 'array:int',
          'acquirerResponse' => '\Paysafe\CardPayments\AcquirerResponse',
+         'storedCredential' => 'string',
          'error' => '\Paysafe\Error',
          'links' => 'array:\Paysafe\Link'
     );


### PR DESCRIPTION
According to the documentation this field should be of class `\Paysafe\CardPayments\StoredCredentials` but I couldn't find that class so I think just a `string` should be a good temporary solution until the proper class is created.