### PR TITLE
Allow updating card from singleUseToken

### DIFF
--- a/source/Paysafe/CustomerVaultService.php
+++ b/source/Paysafe/CustomerVaultService.php
@@ -217,6 +217,66 @@ class CustomerVaultService
 
         return new CustomerVault\Profile($response);
     }
+    
+    /**
+     * Get the profile by merchant customer id.
+     *
+     * @param \Paysafe\CustomerVault\Profile $profile
+     * @param bool $includeAddresses
+     * @param bool $includeCards
+     * @param bool $includeachbankaccount
+     * @param bool $includeeftbankaccount
+     * @param bool $includebacsbankaccount
+     * @param bool $includesepabankaccount
+     * @return bool
+     * @throws PaysafeException
+     */
+    public function getProfileCustomerId( CustomerVault\Profile $profile, $includeAddresses = false, $includeCards = false, $includeachbankaccount = false, $includeeftbankaccount = false, $includebacsbankaccount = false, $includesepabankaccount = false )
+    {
+        $profile->setRequiredFields(array('merchantCustomerId'));
+        $profile->checkRequiredFields();
+
+        $fields = array();
+        if ($includeAddresses)
+        {
+            $fields[] = 'addresses';
+        }
+        if ($includeCards)
+        {
+            $fields[] = 'cards';
+        }
+        if ($includeachbankaccount)
+        {
+            $fields[] = 'achbankaccounts';
+        }
+        if ($includeeftbankaccount)
+        {
+            $fields[] = 'eftbankaccounts';
+        }
+        if ($includebacsbankaccount)
+        {
+            $fields[] = 'bacsbankaccounts';
+        }
+        if ($includesepabankaccount)
+        {
+            $fields[] = 'sepabankaccounts';
+        }
+
+        $queryStr = array();
+        if ($fields)
+        {
+            $queryStr['fields'] = join(',', $fields);
+        }
+
+        $request = new Request(array(
+            'method' => Request::GET,
+            'uri' => $this->prepareURI("/profiles?merchantCustomerId=" . $profile->merchantCustomerId),
+            'queryStr' => $queryStr
+        ));
+        $response = $this->client->processRequest($request);
+
+        return new CustomerVault\Profile($response);
+    }
 
     /**
      * Create address.

--- a/source/Paysafe/CustomerVaultService.php
+++ b/source/Paysafe/CustomerVaultService.php
@@ -432,6 +432,35 @@ class CustomerVaultService
 
         return new CustomerVault\Card($response);
     }
+    
+    /**
+     * Update card from single use token.
+     *
+     * @param \Paysafe\CustomerVault\Card $card
+     * @return \Paysafe\CustomerVault\Card
+     * @throws PaysafeException
+     */
+    public function updateCardFromSingleUseToken( CustomerVault\Card $card )
+    {
+        $card->setRequiredFields(array(
+            'profileID',
+            'id'
+        ));
+        $card->checkRequiredFields();
+        $card->setRequiredFields(array(
+            'singleUseToken',
+        ));
+
+        $request = new Request(array(
+            'method' => Request::PUT,
+            'uri' => $this->prepareURI("/profiles/" . $card->profileID . "/cards/" . $card->id),
+            'body' => $card
+        ));
+        $response = $this->client->processRequest($request);
+        $response['profileID'] = $card->profileID;
+
+        return new CustomerVault\Card($response);
+    }
 
     /**
      * Delete card.


### PR DESCRIPTION
updateCard fails because there's no way to pass singleUseToken as outlined in #33. Closes #33.

I had initially created a check inside updateCard for the singleUseToken, but I am now noticing the pattern already initialized with createCardFromSingleUseToken to have different functions and I applied it here too.