### PR TITLE
Removed print calls in CustomerVaultService class

### DIFF
--- a/source/Paysafe/CustomerVaultService.php
+++ b/source/Paysafe/CustomerVaultService.php
@@ -642,9 +642,7 @@ class CustomerVaultService
             'uri' => $this->prepareURI("/profiles/" . $profile->id . "/achbankaccounts/" . $bankDetails->id),
             'body' => $profile
         ));
-        print_r($request);
         $response = $this->client->processRequest($request);
-        print_r($response);
         return new CustomerVault\ACHBankaccounts($response);
     }
 


### PR DESCRIPTION
There appear to be debug `print_r()` functions left in the `CustomerVaultService` class. This PR removes those functions.